### PR TITLE
区分通用版和定制版

### DIFF
--- a/.github/workflows/Python-Build.yml
+++ b/.github/workflows/Python-Build.yml
@@ -27,12 +27,12 @@ jobs:
         rm dist -Recurse -Force -ErrorAction Continue
         pyinstaller --onefile -w -i Assets\icon.ico CustomTextDisplayTool.py
         pyinstaller -w -i Assets\icon.ico CustomTextDisplayTool.py
+        pyinstaller -w --distpath dist/CustomTextDisplayTool_bsdnsxx -n CustomTextDisplayTool -i Assets\icon.ico CustomTextDisplayTool_bsdnsxx.py
 
     - name: Package portable EXE
       run: |
         mkdir -p release
-        cd dist
-        Compress-Archive -Path ./CustomTextDisplayTool.exe -DestinationPath ../release/CustomTextDisplayTool_Portable.zip
+        Compress-Archive -Path dist/CustomTextDisplayTool.exe -DestinationPath ../release/CustomTextDisplayTool_Portable.zip
         echo 'Successfully packaged "CustomTextDisplayTool_Portable".'
 
     - name: Upload portable EXE to GitHub Actions
@@ -46,6 +46,34 @@ jobs:
       with:
         name: CustomTextDisplayTool
         path: dist/CustomTextDisplayTool/
+
+    - name: Upload bsdnsxx Customized EXE to GitHub Actions
+      uses: actions/upload-artifact@v4
+      with:
+        name: CustomTextDisplayTool_bsdnsxx
+        path: dist/CustomTextDisplayTool_bsdnsxx/CustomTextDisplayTool/
+
+    - name: Temporary copy the bsdnsxx Customized EXE to the repository
+      run: |
+        rm "CustomTextDisplayTool/Bin" -Recurse -Force -ErrorAction Continue
+        mkdir -p "CustomTextDisplayTool/Bin"
+        Copy-Item -Path "dist/CustomTextDisplayTool_bsdnsxx/CustomTextDisplayTool/*" -Destination "CustomTextDisplayTool/Bin/" -Recurse -Force
+        ls CustomTextDisplayTool -Recurse -Force
+
+    - name: Install NSIS
+      run: |
+        Start-Process -FilePath 'NSIS\nsis-3.08-setup.exe' -ArgumentList '/S' -NoNewWindow -Wait
+        echo 'Installed successfully.'
+
+    - name: Create Installer
+      run: |
+        Start-Process -FilePath 'C:/Program Files (x86)/NSIS/makensis.exe' -ArgumentList 'NSIS/CustomTextDisplayTool.nsi' -NoNewWindow -Wait
+
+    - name: Upload bsdnsxx Customized Installer to GitHub Actions
+      uses: actions/upload-artifact@v4
+      with:
+        name: CustomTextDisplayTool_bsdnsxx_Installer
+        path: NSIS/CustomTextDisplayTool_Setup.exe
 
     - name: Configure SSH
       run: |
@@ -75,20 +103,16 @@ jobs:
       env:
         GIT_SSH_COMMAND: 'ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
 
-    - name: Install NSIS
-      run: |
-        Start-Process -FilePath 'NSIS\nsis-3.08-setup.exe' -ArgumentList '/S' -NoNewWindow -Wait
-        echo 'Installed successfully.'
-
     - name: Create Installer
       run: |
+        rm NSIS/CustomTextDisplayTool_Setup.exe -Force -ErrorAction Continue
         Start-Process -FilePath 'C:/Program Files (x86)/NSIS/makensis.exe' -ArgumentList 'NSIS/CustomTextDisplayTool.nsi' -NoNewWindow -Wait
         cp -r NSIS/CustomTextDisplayTool_Setup.exe release/
 
     - name: Upload Installer to GitHub Actions
       uses: actions/upload-artifact@v4
       with:
-        name: CustomTextDisplayTool-Installer
+        name: CustomTextDisplayTool_Installer
         path: release/CustomTextDisplayTool_Setup.exe
 
     - name: Print files from release dir

--- a/CustomTextDisplayTool_bsdnsxx.py
+++ b/CustomTextDisplayTool_bsdnsxx.py
@@ -247,7 +247,6 @@ class TemplateFrame(wx.Frame):
             self.panel, label="填充默认模版", pos=(170, 500), size=(80, -1)
         )
         self.use_button.Bind(wx.EVT_BUTTON, self.template_text)
-        self.use_button.Enable(False)
 
         # 保存模版按钮
         self.submit_button = wx.Button(
@@ -268,15 +267,13 @@ class TemplateFrame(wx.Frame):
         self.hide_button.Bind(wx.EVT_BUTTON, self.hide_Template_Frame)
 
     def template_text(self, event):
-        print("该功能无法使用!仅定制版包含此功能!")
-        wx.MessageBox("该功能无法使用!\n仅定制版包含此功能!", "错误", wx.OK | wx.ICON_ERROR)
-        # self.text_ctrl.SetValue("")
-        # self.font_size_input.SetValue(18)
-        # self.font_weight_combo.SetSelection(0)
-        # template_color = self.string_to_color(str("#000000"))
-        # print("默认模板字体颜色:", template_color)
-        # self.color_label.SetForegroundColour(template_color)
-        # self.Refresh()
+        self.text_ctrl.SetValue("如需定制播放生日歌等歌曲, 请联系九1班黄炜轩")
+        self.font_size_input.SetValue(18)
+        self.font_weight_combo.SetSelection(1)
+        template_color = self.string_to_color(str("#000000"))
+        print("默认模板字体颜色:", template_color)
+        self.color_label.SetForegroundColour(template_color)
+        self.Refresh()
 
     def on_select_color(self, event):
         color_data = wx.ColourData()

--- a/README.md
+++ b/README.md
@@ -92,13 +92,15 @@ bilibili 主页：[点击访问](https://space.bilibili.com/1056060818)
 > >
 > > 5.2 [nsis-3.08-setup.exe](NSIS/nsis-3.08-setup.exe): NSIS 主程序安装包
 > 
-> 6 [CustomTextDisplayTool.py](CustomTextDisplayTool.py): 软件源代码
+> 6 [CustomTextDisplayTool.py](CustomTextDisplayTool.py): 软件通用版源代码
 > 
-> 7 [.gitignore](.gitignore): Git Ignore 配置文件
+> 7 [CustomTextDisplayTool_bsdnsxx.py](CustomTextDisplayTool_bsdnsxx.py): 软件北师大南山附校定制版源代码
+> 
+> 8 [.gitignore](.gitignore): Git Ignore 配置文件
 >
-> 8 [LICENSE](LICENSE): 本仓库开源许可证&版权
+> 9 [LICENSE](LICENSE): 本仓库开源许可证&版权
 >
-> 9 [README.md](README.md): 本仓库说明文档
+> 10 [README.md](README.md): 本仓库说明文档
 
 ## 许可证
 


### PR DESCRIPTION
## 区分通用版和定制版
2025/1/4

- 使用不同源代码文件区分通用版和定制版，通用版禁用模板编辑窗口中填充默认模版按钮
- 修改 `Python Release and Build` 工作流配置文件以适配通用版和定制版，定制版不上传至Release
- 修改仓库说明文档 `README.md`  中的仓库目录结构，添加定制版源文件超链接